### PR TITLE
会員登録した情報の閲覧・編集・退会処理

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,11 @@ class ApplicationController < ActionController::Base
   before_action :configure_premitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    public_about_path #仮
+    homes_about_path #仮
   end
 
   def after_sign_out_path_for(resource)
-    public_about_path #仮
+    homes_about_path #仮
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,11 @@ class ApplicationController < ActionController::Base
   before_action :configure_premitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    homes_about_path #仮
+    customers_mypage_path
   end
 
   def after_sign_out_path_for(resource)
-    homes_about_path #仮
+    homes_top_path
   end
 
   protected

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,19 +1,46 @@
 class Public::CustomersController < ApplicationController
-before_action :authenticate_user!, except: [:top, :homes]
+before_action :authenticate_customer!, except: [:top, :homes]
 
   def show
-    @customer = Customer.find(current_customer)
+    @customer = Customer.find(current_customer.id)
   end
 
   def edit
+    @customer = Customer.find(current_customer.id)
+  end
+
+  def update
+    customer = Customer.find(current_customer.id)
+    if customer.update(customer_params)
+      flash[:notice] = "会員情報が編集されました"
+      redirect_to customers_mypage_path
+    else
+      @customer = customer
+      render :edit
+    end
   end
 
   def confirm
   end
 
-  def update
-  end
+
 
   def withdraw
   end
+
+  private
+
+  def customer_params
+    params.require(:customer).permit(
+      :last_name,
+      :first_name,
+      :last_name_kana,
+      :first_name_kana,
+      :post_code,
+      :address,
+      :phone_number,
+      :email
+      )
+  end
+
 end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -20,12 +20,12 @@ before_action :authenticate_customer!, except: [:top, :homes]
     end
   end
 
-  def confirm
-  end
-
-
-
   def withdraw
+    customer = Customer.find(current_customer.id)
+    customer.update(is_deleted: true)
+    reset_session
+    flash[:notice] = "正常に退会いたしました"
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,10 +1,19 @@
 class Public::CustomersController < ApplicationController
+before_action :authenticate_user!, except: [:top, :homes]
+
   def show
+    @customer = Customer.find(current_customer)
   end
 
   def edit
   end
 
   def confirm
+  end
+
+  def update
+  end
+
+  def withdraw
   end
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :reject_invalid_customer, only: [:create]
 
   # GET /resource/sign_in
   # def new
@@ -18,10 +19,25 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  def reject_invalid_customer
+    customer = Customer.find_by(email: params[:customer][:email])
+    # 会員情報が存在する場合
+    if customer
+      if customer.valid_password?(params[:customer][:password]) && (customer.is_deleted == true )
+        flash[:notice] = "退会済みです。再度ご登録をしてご利用ください"
+        redirect_to new_customer_registration_path
+      else
+        flash[:notice] = "入力情報が正しくありません"
+      end
+    else
+      flash[:notice] = "該当するユーザーが見つかりません"
+    end
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -51,7 +51,7 @@
 
 .middle-padding {
   padding: 0 2rem;
-
+}
 
 //会員登録・ログイン
 .header_padding {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -78,3 +78,34 @@
 .field-address {
   width: 100%;
 }
+
+//customers/mypage
+.subtitle-width {
+  width: 100px;
+}
+
+//form内のinputの無いlabel用<p>
+.label-name {
+  display: inline-block;
+  margin-bottom: 8px;
+}
+
+.padding-y {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.padding-x {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.margin-x {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.margin-y {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}

--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -1,0 +1,19 @@
+<% if model.errors.any? %>
+<div>
+
+<h3><%= model.errors.count %>
+  <% if model.errors.count >= 2 %>
+  errors
+  <% else %>
+  error
+  <% end %>
+  prohibited this obj from being saved:
+</h3>
+<ul>
+  <% model.errors.full_messages.each do |message| %>
+  <li><%= message %></li>
+  <% end %>
+</ul>
+
+</div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
   <body>
 
+
     <nav class="navbar navbar-expand-md navbar-light nav-style">
         <div class="windowLayout container-fluid">
           <a class="navbar-brand" href="#">Navbar</a>
@@ -32,6 +33,7 @@
         </div>
 
       </nav>
+    <%= flash[:notice] %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,11 @@
   </head>
 
   <body>
-
-
     <nav class="navbar navbar-expand-md navbar-light nav-style">
         <div class="windowLayout container-fluid">
-          <a class="navbar-brand" href="#">Navbar</a>
+          <a class="navbar-brand" href="/homes/top">Navbar</a>
           <% if customer_signed_in? %>
-            <p class="m-0">ようこそ○○さん</p>
+            <p class="m-0">ようこそ <%= "#{current_customer.last_name} #{current_customer.first_name}" %> さん</p>
           <% end %>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
             data-bs-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false"
@@ -27,7 +25,7 @@
           <div class="collapse navbar-collapse justify-content-end" id="navbarNavAltMarkup">
             <div class="navbar-nav">
               <% if customer_signed_in? %>
-                <a class="nav-link px-3" href="/public/customers/show">マイページ</a>
+                <a class="nav-link px-3" href="/customers/mypage">マイページ</a>
                 <a class="nav-link px-3" href="/public/items/index">商品一覧</a>
                 <a class="nav-link px-3" href="/public/cart_items/index">カート</a>
                 <li class="nav-item px-3">
@@ -42,7 +40,7 @@
                   <%= link_to "ログアウト", destroy_admin_session_path, method: :delete, class: 'nav-link'  %>
                 </li>
               <% else %>
-                <a class="nav-link px-3" href="/public/homes/about">About</a>
+                <a class="nav-link px-3" href="/homes/about">About</a>
                 <a class="nav-link px-3" href="/public/items/index">商品一覧</a>
                 <a class="nav-link px-3" href="/customers/sign_up">新規登録</a>
                 <a class="nav-link px-3" href="/customers/sign_in">ログイン</a>

--- a/app/views/public/customers/confirm.html.erb
+++ b/app/views/public/customers/confirm.html.erb
@@ -1,2 +1,17 @@
-<h1>Public::Customers#confirm</h1>
-<p>Find me in app/views/public/customers/confirm.html.erb</p>
+<div class="container" style="width: fit-content">
+
+  <div class="sub_container_position text-center">
+    <h4>本当に退会しますか？</h4>
+    <p class="margin-y">
+      退会すると、会員登録情報や<br>
+      これまでの購入履歴が閲覧できなくなります。<br>
+      退会する場合は、「退会する」をクリックしてください。
+    </p>
+    <div >
+      <%= link_to "退会しない", customers_mypage_path, class: "btn btn-primary padding-x margin-x" %>
+      <%= link_to "退会する", customers_withdraw_path, methed: :patch, class: "btn btn-danger padding-x margin-x" %>
+    </div>
+
+  </div>
+
+</div>

--- a/app/views/public/customers/confirm.html.erb
+++ b/app/views/public/customers/confirm.html.erb
@@ -9,7 +9,7 @@
     </p>
     <div >
       <%= link_to "退会しない", customers_mypage_path, class: "btn btn-primary padding-x margin-x" %>
-      <%= link_to "退会する", customers_withdraw_path, methed: :patch, class: "btn btn-danger padding-x margin-x" %>
+      <%= link_to "退会する", customers_withdraw_path, method: :PATCH, class: "btn btn-danger padding-x margin-x", "data-confirm"=>"本当に退会しますか？" %>
     </div>
 
   </div>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -4,63 +4,47 @@
     <h4><span>会員情報編集</span></h4>
 
       <%= form_with model: @customer, url: customers_introduction_path, method: :patch do |f| %>
-      <%#= render "public/shared/error_messages", resource: resource %>
-      <div class="margin-y">
-        <div class="field">
+      <%= render "layouts/form_errors", model: @customer %>
+
+      <div class="field margin-y">
+        <div class="d-flex">
           <p class="label-width label-name">名前</p>
-          <span class="label-position" style="margin-left: -52px">
-            <%= f.label :last_name, "（姓）" %>
-          </span>
-          <span>
+            <%= f.label :last_name, "（姓）", class: "label-position", style: "margin-left: -48px" %>
             <%= f.text_field :last_name, placeholder: "令和", class: "field-width" %>
-          </span>
 
-          <span class="label-position" style="margin-left: 16px">
-            <%= f.label :first_name, "（名）" %>
-          </span>
-          <span>
+            <%= f.label :first_name, "（名）", class: "label-position", style: "margin-left: 16px" %>
             <%= f.text_field :first_name, placeholder: "道子", class: "field-width"%>
-          </span>
         </div>
 
-        <div class="field">
+        <div class="d-flex">
           <p class="label-width label-name">フリガナ</p>
-          <span class="label-position" style="margin-left: -68px">
-            <%= f.label :last_name_kana, "（セイ）" %>
-          </span>
-          <span>
-            <%= f.text_field :last_name_kana, placeholder: "レイワ", class: "field-width" %>
-          </span>
+            <%= f.label :last_name_kana, "（セイ）", class: "label-position", style: "margin-left: -64px" %>
+            <%= f.text_field :last_name_kana, placeholder: "令和", class: "field-width" %>
 
-          <span style="position: relative;">
-            <%= f.label :first_name_kana, "（メイ）" %>
-          </span>
-          <span>
-            <%= f.text_field :first_name_kana, placeholder: "ミチコ", class: "field-width" %>
-          </span>
+            <%= f.label :first_name_kana, "（メイ）", class: "label-position"%>
+            <%= f.text_field :first_name_kana, placeholder: "道子", class: "field-width"%>
         </div>
 
-        <div class="field">
-          <%= f.label :post_code, "郵便番号（ハイフンなし）", class: "label-width" %>
+        <div class="d-flex">
+          <%= f.label :post_code, "郵便番号（ハイフンなし）", class: "label-width"  %>
           <%= f.text_field :post_code, placeholder: "0000000", class: "field-width" %>
         </div>
 
-        <div class="field" style="width: 100%">
-          <%= f.label :address, "住所", class: "label-width" %>
+        <div class="d-flex" style="width: 100%">
+          <%= f.label :address, "住所", class: "label-width"  %>
           <%= f.text_field :address, placeholder: "東京都渋谷区代々木神園町0-0", style: "width:472px" %>
         </div>
 
-        <div class="field">
+        <div class="d-flex">
           <%= f.label :phone_number, "電話番号", class: "label-width"  %>
           <%= f.text_field :phone_number, placeholder: "00000000000", class: "field-width" %>
         </div>
 
-        <div class="field">
+        <div class="d-flex">
           <%= f.label :email, "メールアドレス", class: "label-width" %>
           <%= f.email_field :email, autocomplete: "email", placeholder: "example@example.com", class: "field-width" %>
         </div>
       </div>
-
       <div class="actions d-flex justify-content-around">
         <%= f.submit "編集内容を保存", class: "btn btn-success" %>
         <%= link_to "退会する", customers_confirm_path, class: "btn btn-danger" %>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,2 +1,72 @@
-<h1>Public::Customers#edit</h1>
-<p>Find me in app/views/public/customers/edit.html.erb</p>
+<div class="container" style="width: fit-content">
+
+  <div class="sub_container_position">
+    <h4><span>会員情報編集</span></h4>
+
+      <%= form_with model: @customer, url: customers_introduction_path, method: :patch do |f| %>
+      <%#= render "public/shared/error_messages", resource: resource %>
+      <div class="margin-y">
+        <div class="field">
+          <p class="label-width label-name">名前</p>
+          <span class="label-position" style="margin-left: -52px">
+            <%= f.label :last_name, "（姓）" %>
+          </span>
+          <span>
+            <%= f.text_field :last_name, placeholder: "令和", class: "field-width" %>
+          </span>
+
+          <span class="label-position" style="margin-left: 16px">
+            <%= f.label :first_name, "（名）" %>
+          </span>
+          <span>
+            <%= f.text_field :first_name, placeholder: "道子", class: "field-width"%>
+          </span>
+        </div>
+
+        <div class="field">
+          <p class="label-width label-name">フリガナ</p>
+          <span class="label-position" style="margin-left: -68px">
+            <%= f.label :last_name_kana, "（セイ）" %>
+          </span>
+          <span>
+            <%= f.text_field :last_name_kana, placeholder: "レイワ", class: "field-width" %>
+          </span>
+
+          <span style="position: relative;">
+            <%= f.label :first_name_kana, "（メイ）" %>
+          </span>
+          <span>
+            <%= f.text_field :first_name_kana, placeholder: "ミチコ", class: "field-width" %>
+          </span>
+        </div>
+
+        <div class="field">
+          <%= f.label :post_code, "郵便番号（ハイフンなし）", class: "label-width" %>
+          <%= f.text_field :post_code, placeholder: "0000000", class: "field-width" %>
+        </div>
+
+        <div class="field" style="width: 100%">
+          <%= f.label :address, "住所", class: "label-width" %>
+          <%= f.text_field :address, placeholder: "東京都渋谷区代々木神園町0-0", style: "width:472px" %>
+        </div>
+
+        <div class="field">
+          <%= f.label :phone_number, "電話番号", class: "label-width"  %>
+          <%= f.text_field :phone_number, placeholder: "00000000000", class: "field-width" %>
+        </div>
+
+        <div class="field">
+          <%= f.label :email, "メールアドレス", class: "label-width" %>
+          <%= f.email_field :email, autocomplete: "email", placeholder: "example@example.com", class: "field-width" %>
+        </div>
+      </div>
+
+      <div class="actions d-flex justify-content-around">
+        <%= f.submit "編集内容を保存", class: "btn btn-success" %>
+        <%= link_to "退会する", customers_confirm_path, class: "btn btn-danger" %>
+      </div>
+    <% end %>
+
+  </div>
+
+</div>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,2 +1,53 @@
-<h1>Public::Customers#show</h1>
-<p>Find me in app/views/public/customers/show.html.erb</p>
+<div class="container">
+
+  <div class="sub_container_position">
+    <h4><span>マイページ</span></h4>
+    <br>
+    <div class="d-flex">
+      <h5 class="subtitle-width">登録情報</h5>
+      <p><%= link_to "編集する", customers_introduction_edit_path, class: "btn btn-success" %></p>
+    </div>
+    <table class="table table-bordered">
+      <tbody>
+        <tr>
+          <td>氏名</td>
+          <td><%= "#{@customer.last_name} #{@customer.first_name}" %></td>
+        </tr>
+        <tr>
+          <td>カナ</td>
+          <td><%= "#{@customer.last_name_kana} #{@customer.first_name_kana}" %></td>
+        </tr>
+        <tr>
+          <td>郵便番号</td>
+          <td><%= @customer.post_code %></td>
+        </tr>
+        <tr>
+          <td>住所</td>
+          <td><%= @customer.address %></td>
+        </tr>
+        <tr>
+          <td>電話番号</td>
+          <td><%= @customer.phone_number %></td>
+        </tr>
+        <tr>
+          <td>メールアドレス</td>
+          <td><%= @customer.email %></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="d-flex">
+      <h5 class="subtitle-width">配送先</h5>
+      <p><%= link_to "一覧を見る", shipping_addresses_path, class: "btn btn-primary" %></p>
+    </div>
+
+    <div class="d-flex">
+      <h5 class="subtitle-width">注文履歴</h5>
+      <p><%= link_to "一覧を見る", orders_path, class: "btn btn-primary" %></p>
+    </div>
+
+  </div>
+
+  </div>
+
+</div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -5,74 +5,58 @@
     <%= form_with model: @customer, url: customer_registration_path do |f| %>
       <%= render "public/shared/error_messages", resource: resource %>
 
-      <div class="field">
-        <%= f.label "名前", class: "label-width" %>
-        <span class="label-position" style="margin-left: -52px">
-          <%= f.label :last_name, "（姓）" %>
-        </span>
-        <span>
+    <div class="field margin-y">
+      <div class="d-flex">
+        <p class="label-width label-name">名前</p>
+          <%= f.label :last_name, "（姓）", class: "label-position", style: "margin-left: -48px" %>
           <%= f.text_field :last_name, placeholder: "令和", class: "field-width" %>
-        </span>
 
-        <span class="label-position" style="margin-left: 16px">
-          <%= f.label :first_name, "（名）" %>
-        </span>
-        <span>
+          <%= f.label :first_name, "（名）", class: "label-position", style: "margin-left: 16px" %>
           <%= f.text_field :first_name, placeholder: "道子", class: "field-width"%>
-        </span>
       </div>
 
-      <div class="field">
-        <%= f.label "フリガナ", class: "label-width" %>
-        <span class="label-position" style="margin-left: -68px">
-          <%= f.label :last_name_kana, "（セイ）" %>
-        </span>
-        <span>
-          <%= f.text_field :last_name_kana, placeholder: "レイワ", class: "field-width" %>
-        </span>
+      <div class="d-flex">
+        <p class="label-width label-name">フリガナ</p>
+          <%= f.label :last_name_kana, "（セイ）", class: "label-position", style: "margin-left: -64px" %>
+          <%= f.text_field :last_name_kana, placeholder: "令和", class: "field-width" %>
 
-        <span style="position: relative;">
-          <%= f.label :first_name_kana, "（メイ）" %>
-        </span>
-        <span>
-          <%= f.text_field :first_name_kana, placeholder: "ミチコ", class: "field-width" %>
-        </span>
-
+          <%= f.label :first_name_kana, "（メイ）", class: "label-position"%>
+          <%= f.text_field :first_name_kana, placeholder: "道子", class: "field-width"%>
       </div>
 
-      <div class="field">
+      <div class="d-flex">
         <%= f.label :email, "メールアドレス", class: "label-width" %>
         <%= f.email_field :email, autocomplete: "email", placeholder: "example@example.com", class: "field-width" %>
       </div>
 
-      <div class="field">
+      <div class="d-flex">
         <%= f.label :post_code, "郵便番号（ハイフンなし）", class: "label-width"  %>
         <%= f.text_field :post_code, placeholder: "0000000", class: "field-width" %>
       </div>
 
-      <div class="field" style="width: 100%">
+      <div class="d-flex" style="width: 100%">
         <%= f.label :address, "住所", class: "label-width"  %>
         <%= f.text_field :address, placeholder: "東京都渋谷区代々木神園町0-0", style: "width:472px" %>
       </div>
 
-      <div class="field">
+      <div class="d-flex">
         <%= f.label :phone_number, "電話番号", class: "label-width"  %>
         <%= f.text_field :phone_number, placeholder: "00000000000", class: "field-width" %>
       </div>
 
-      <div class="field">
+      <div class="d-flex">
         <%= f.label :password, "パスワード（６文字以上）", class: "label-width"  %>
         <%= f.password_field :password, autocomplete: "new-password", class: "field-width" %>
       </div>
 
-      <div class="field">
+      <div class="d-flex">
         <%= f.label :password_confirmation, "パスワード（確認用）", class: "label-width"  %>
         <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "field-width" %>
       </div>
-
-      <div class="actions text-center">
-        <%= f.submit "新規登録", class: "btn btn-success" %>
-      </div>
+    </div>
+    <div class="actions text-center">
+      <%= f.submit "新規登録", class: "btn btn-success padding-x" %>
+    </div>
     <% end %>
   </div>
 

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -2,25 +2,23 @@
 
   <div class="sub_container_position">
   <h4><span>ログイン</span></h4>
+  <br>
+  <h5><span>会員の方はこちらからログイン</span></h5>
+    <%= form_with model: @customer, url: customer_session_path do |f| %>
+      <div class="field">
+        <%= f.label :email, "メールアドレス", class: "label-width"  %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@example.com" %>
+      </div>
 
-<br>
-    <h5><span>会員の方はこちらからログイン</span></h5>
-      <%= form_with model: @customer, url: customer_session_path do |f| %>
-        <div class="field">
-          <%= f.label :email, "メールアドレス", class: "label-width"  %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@example.com" %>
-        </div>
+      <div class="field">
+        <%= f.label :password, "パスワード", class: "label-width"  %>
+        <%= f.password_field :password, autocomplete: "current-password" %>
+      </div>
 
-        <div class="field">
-          <%= f.label :password, "パスワード", class: "label-width"  %>
-          <%= f.password_field :password, autocomplete: "current-password" %>
-        </div>
-
-        <div class="actions text-center">
-          <%= f.submit "ログイン", class: "btn btn-primary" %>
-        </div>
-      <% end %>
-
+      <div class="actions text-center">
+        <%= f.submit "ログイン", class: "btn btn-primary" %>
+      </div>
+    <% end %>
   </div>
 
   <div class="sub_container_position">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   root to: 'public/homes#top'
   scope module: :public do
+    get 'customers/mypage' => 'customers#show'
+    get 'customers/introduction/edit' => 'customers#edit'
+    patch 'customers/introduction' => 'customers#update'
+    get 'customers/confirm' => 'customers#confirm'
+    patch 'customers/withdraw' => 'customers#withdraw'
+
     get 'homes/top' => 'homes#top'
     get 'homes/about' => 'homes#about'
   end
@@ -25,26 +31,20 @@ Rails.application.routes.draw do
   namespace :admin do
     get 'homes/top'
   end
-  namespace :public do
-    get 'shipping_addresses/index'
-    get 'shipping_addresses/edit'
+  scope module: :public do
+    get 'shipping_addresses' => 'shipping_addresses#index'
+    get 'shipping_addresses/id/edit' => 'shipping_addresses#edit', as: 'shipping_addresses_edit'
   end
-  namespace :public do
-    get 'orders/new'
-    get 'orders/index'
-    get 'orders/complete'
-    get 'orders/show'
+  scope module: :public do
+    get 'orders' => 'orders#index'
+    get 'orders/new' => 'orders#new'
+    get 'orders/complete' => 'orders#complete'
+    get 'orders/show' => 'orders#show'
   end
   namespace :public do
     get 'cart_items/index'
   end
-  scope module: :public do
-    get 'customers/mypage' => 'customers#show'
-    get 'customers/introduction/edit' => 'customers#edit'
-    patch 'customers/introduction' => 'customers#update'
-    get 'customers/confirm' => 'customers#confirm'
-    patch 'customers/withdraw' => 'customers#withdraw'
-  end
+
   namespace :public do
     get 'items/index'
     get 'items/show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  # root to: 'homes#about'
-  # root to: 'public/homes#about'
+  root to: 'public/homes#top'
   scope module: :public do
     get 'homes/top' => 'homes#top'
     get 'homes/about' => 'homes#about'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  # root to: 'homes#about'
+  # root to: 'public/homes#about'
+  scope module: :public do
+    get 'homes/top' => 'homes#top'
+    get 'homes/about' => 'homes#about'
+  end
   namespace :admin do
     get 'orders/show'
   end
@@ -33,19 +39,21 @@ Rails.application.routes.draw do
   namespace :public do
     get 'cart_items/index'
   end
-  namespace :public do
-    get 'customers/show'
-    get 'customers/edit'
-    get 'customers/confirm'
+  scope module: :public do
+    get 'customers/mypage' => 'customers#show'
+    get 'customers/introduction/edit' => 'customers#edit'
+    patch 'customers/introduction' => 'customers#update'
+    get 'customers/confirm' => 'customers#confirm'
+    patch 'customers/withdraw' => 'customers#withdraw'
   end
   namespace :public do
     get 'items/index'
     get 'items/show'
   end
-  namespace :public do
-    get 'homes/top', as: 'top'
-    get 'homes/about', as: 'about'
-  end
+  # namespace :public do
+  #   get 'homes/top', as: 'top'
+  #   get 'homes/about', as: 'about'
+  # end
 # 顧客用
 # URL /customers/sign_in ...
 devise_for :customers,skip: [:passwords], controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,10 +49,7 @@ Rails.application.routes.draw do
     get 'items/index'
     get 'items/show'
   end
-  # namespace :public do
-  #   get 'homes/top', as: 'top'
-  #   get 'homes/about', as: 'about'
-  # end
+  
 # 顧客用
 # URL /customers/sign_in ...
 devise_for :customers,skip: [:passwords], controllers: {


### PR DESCRIPTION
## 会員登録情報
- 情報の閲覧
- 情報の編集
- 会員の退会
- 会員のNavbarについて左側のブランド名のリンク先がなかったので、homes/topを入れました。
- 会員がログインしていた場合、「ようこそ○○さん」に名前が出るよう変更しました。

## できるようになったこと：
- form_errorテンプレート作成により、<%= render "layouts/form_errors", model: @customer %>を入力することでフォームのエラー文が出る。「@customer」はそれぞれのモデルに置き換えてください。
- 「before_action :authenticate_customer!」でログインしているかどうかの認証ができる。必要な場合はonlyやexceptをご使用ください。
- SCSS内にCSSクラスを追加しました。使用ご自由にどうぞ。
・padding-y：上下のpaddingが少し欲しい。
・padding-x：左右のpaddingが少し欲しい。
・margin-y：上下のmarginが少し欲しい。
・margin-x：左右のmarginが少し欲しい。

## 各自修正のお願い：
- 以前使用していたフォームテンプレートがエラーが起きた際に崩れてしまうのを直しました。お手数おかけしますが、テンプレートを使用した方、修正をお願いします。