### PR TITLE
商品一覧・商品詳細のレイアウト編集

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -150,6 +150,12 @@
   object-position: center;
 }
 
+.card-image-show {
+  height: 230px;
+  object-fit: cover;
+  object-position: center;
+}
+
 .align-right {
   text-align: end;
 }

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,30 +1,21 @@
-<div class="container" style="width: fit-content">
-<h1>会員一覧</h1>
-<div class="row">
-  <div class="col-xs-1"></div>
-
-    <div class="col-xs-10">
-    <table class="table customer-table">
+<div class="container w-75">
+  <div class="margin-y">
+    <h4>会員一覧</h4>
+    <table class='table margin-y'>
       <thead>
         <tr>
-          <th class="active">会員ID</th>
-          <th class="active">氏名</th>
-          <th class="active">メールアドレス</th>
-          <th class="active">ステータス</th>
+          <th>会員ID</th>
+          <th>氏名</th>
+          <th>メールアドレス</th>
+          <th>ステータス</th>
         </tr>
       </thead>
       <tbody>
         <% @customers.each do |customer| %>
           <tr>
-            <td>
-              <%= customer.id %>
-            </td>
-            <td>
-              <%= link_to (customer.last_name + customer.first_name),admin_customer_path(customer.id) %>
-            </td>
-            <td>
-              <%= customer.email %>
-            </td>
+            <td><%= customer.id %></td>
+            <td><%= link_to (customer.last_name + customer.first_name),admin_customer_path(customer.id) %></td>
+            <td><%= customer.email %></td>
             <td>
               <% if customer.is_deleted %>
                 退会済み
@@ -37,6 +28,4 @@
       </tbody>
     </table>
   </div>
-  <div class="col-xs-1"></div>
-</div>
 </div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,6 +1,9 @@
 <div class="container w-75">
   <div class="margin-y">
-    <h4>商品一覧</h4>
+    <div class="d-flex align-items-center justify-content-between">
+      <h4>商品一覧</h4>
+      <%= link_to '＋', new_admin_item_path, class: "btn btn-lg btn-primary rounded-circle"%>
+    </div>
     <table class='table margin-y'>
       <thead>
         <tr>

--- a/app/views/layouts/_search_genre.html.erb
+++ b/app/views/layouts/_search_genre.html.erb
@@ -1,0 +1,13 @@
+<section class="col-md-3" style="margin-bottom: 2rem">
+  <div class="card border-dark col rounded-0">
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item"><h5 class="text-center">ジャンル検索</h5></li>
+      <% genres.each do |genre|%>
+        <li class="list-group-item border-0">
+          <!--後にlink_toへ変更-->
+          <%= genre.name %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</section>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,19 +1,7 @@
 <div class="margin-y container">
   <div class="row">
 
-    <section class="col-md-3">
-      <div class="card border-dark col-10 rounded-0">
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item"><h5 class="text-center">ジャンル検索</h5></li>
-          <% @genres.each do |genre|%>
-            <li class="list-group-item border-0">
-              <!--後にlink_toへ変更-->
-              <%= genre.name %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    </section>
+    <%= render 'layouts/search_genre', genres: @genres %>
 
     <main class="col-md-9">
       <div class="top-image-box">
@@ -28,27 +16,7 @@
 
       <div class="margin-y">
         <h2>新規商品</h2>
-        <div class="container margin-y">
-          <div class="row">
-            <% @items.each do |item|%>
-            <div class="col-3 p-0">
-              <div style="margin: 5px">
-                <div class="card bg-transparent border-0">
-                  <% if item.image.attached? %>
-                    <%= image_tag item.image, class: "card-img-top rounded-0 card-image" %>
-                  <% else %>
-                    <%= image_tag 'no_image.jpg', class: "card-img-top rounded-0" %>
-                  <% end %>
-                  <div class="card-body">
-                    <h5 class="card-title"><%= item.name %></h5>
-                    <p>￥<%= item.price %></p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'public/items/items_layout', items: @items %>
         <div class="align-right">
           <%= link_to "全ての商品を見る＞", items_path %>
         </div>

--- a/app/views/public/items/_items_layout.html.erb
+++ b/app/views/public/items/_items_layout.html.erb
@@ -1,0 +1,25 @@
+<div class="margin-y">
+  <div class="container margin-y">
+    <div class="row">
+      <% items.each do |item|%>
+      <div class="col-3 p-0">
+        <div style="margin: 5px">
+          <%= link_to item_show_path(item.id), class: "text-decoration-none text-dark" do %>
+          <div class="card bg-transparent border-0">
+            <% if item.image.attached? %>
+              <%= image_tag item.image, class: "card-img-top rounded-0 card-image" %>
+            <% else %>
+              <%= image_tag 'no_image.jpg', class: "card-img-top rounded-0" %>
+            <% end %>
+            <div class="card-body">
+              <h5 class="card-title"><%= item.name %></h5>
+              <p>¥<%= item.add_tax_price.to_s(:delimited) %></p>
+            </div>
+          </div>
+          <% end %>
+        </div>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,41 +1,11 @@
-<div class="container">
+<div class="margin-y container">
+  <div class="row">
 
-  <div class="sub_container_position ml-5">
-    <h4><span>商品詳細</span></h4>
-  <div class='row'>
+    <%= render 'layouts/search_genre', genres: @genres %>
 
-    <!--ジャンル,後ほどジャンル検索追加-->
-    <div class='col-md-2 mt-3 border'>
-      <p class="border-bottom">ジャンル検索</p>
-      <% @genres.each do |genre| %>
-      <%= genre.name %>
-      <% end %>
-    </div>
-
-
-    <!--商品一覧-->
-    <div class='col md-9 mt-3'>
-      <div class="item-list-wrap">
-        <div class="item-list-box">
-          <% @items.each do |item| %>
-            <p><%= link_to item_show_path(item.id) do %>
-              <% if item.image.attached? %>
-                 <%= image_tag item.image, size: "300x200" %>
-              <% else %>
-                <%= image_tag 'no_image', size: "300x200" %>
-              <% end %>
-              <% end %>
-            </p>
-        <div class="item-list-comment"></div>
-        <p><%= item.name %></p>
-        <p>¥<%= item.add_tax_price.to_s(:delimited) %></p>
-
-          <% end %>
-        </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
+    <main class="col-md-9">
+      <h2>商品詳細</h2>
+      <%= render 'public/items/items_layout', items: @items %>
+    </main>
   </div>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,40 +1,44 @@
-<div class="container">
+<div class="margin-y container">
+  <div class="row">
 
-  <div class="sub_container_position ml-5">
-    <h4><span>商品詳細</span></h4>
-  <div class='row'>
+    <%= render 'layouts/search_genre', genres: @genres %>
 
-    <!--ジャンル,後ほどジャンル検索追加-->
-    <div class='col-md-2 mt-3 border'>
-      <p class="border-bottom">ジャンル検索</p>
-      <% @genres.each do |genre| %>
-      <%= genre.name %>
-      <% end %>
-    </div>
+    <main class="col-md-9">
+      <div margin-y>
 
-    <div class='col md-3 mt-3 ml-3'>
-      <% if @item.image.attached? %>
-        <%= image_tag @item.image, size: "300x200" %>
-      <% else %>
-        <%= image_tag 'no_image', size: "300x200" %>
-      <% end %>
-    </div>
+      </div>
+      <h2>商品詳細</h2>
+      <div class="row margin-y">
+        <div class='col-md-5 text-center' style="min-width: 320px">
+          <% if @item.image.attached? %>
+            <%= image_tag @item.image, class: "w-100 rounded-0 card-image-show text-center", style: "max-width: 350px;" %>
+          <% else %>
+            <%= image_tag 'no_image.jpg', class: "w-100 rounded-0" %>
+          <% end %>
+        </div>
 
-    <div class='col md-7 mt-3'>
-        <h5><%= @item.name %></h5>
-        <p><%= @item.introduction %></p>
-        <h5>￥<%= @item.add_tax_price.to_s(:delimited) %>（税込）<h5>
-
-
-      <!--ログインユーザーのみ-->
-     <% if current_customer %>
-      <%= form_with model: @cart_item, url: cart_items_path do |f| %>
-      <%= f.select :quantity, *[1..10], include_blank: "個数選択"%>
-      <%= f.hidden_field :item_id, :value => @item.id %>
-      <%= f.submit "カートに入れる", class: "btn btn-sm btn-success" %>
-      <% end %>
-      <% end %>
-    </div>
-  </div>
+        <div class='col-md-5 d-flex align-items-center justify-content-center'>
+          <div class="margin-y">
+            <div>
+              <h4><%= @item.name %></h4>
+              <p><%= @item.introduction %></p>
+              <h5 class="margin-y">￥<%= @item.add_tax_price.to_s(:delimited) %>（税込）</h5>
+            </div>
+            <div>
+              <!--ログインユーザーのみ-->
+              <% if current_customer %>
+                <%= form_with model: @cart_item, url: cart_items_path do |f| %>
+                <div class="d-flex">
+                  <%= f.select :quantity, *[1..10], {include_blank: "個数選択"}, class: "form-control" %>
+                  <%= f.hidden_field :item_id, :value => @item.id %>
+                  <%= f.submit "カートに入れる", class: "btn btn-sm btn-success  margin-x" %>
+                </div>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
   </div>
 </div>

--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -29,7 +29,7 @@
             <td><%= shipping_address.address %></td>
             <td><%= shipping_address.name %></td>
             <td class="text-center">
-              <%= link_to '編集する', edit_shipping_address_path(shipping_address), class: "btn btn-sm btn-success" %>
+              <%= link_to '編集する', shipping_addresses_path(shipping_address), class: "btn btn-sm btn-success" %>
             </td>
             <td class="text-center">
               <%= link_to '削除する', shipping_address_path(shipping_address), method: :delete, data: { confirm: '本当に消しますか？' }, class: "btn btn-sm btn-danger"%>

--- a/app/views/public/shipping_addresses/index.html.erb
+++ b/app/views/public/shipping_addresses/index.html.erb
@@ -29,7 +29,7 @@
             <td><%= shipping_address.address %></td>
             <td><%= shipping_address.name %></td>
             <td class="text-center">
-              <%= link_to '編集する', shipping_addresses_path(shipping_address), class: "btn btn-sm btn-success" %>
+              <%= link_to '編集する', edit_shipping_address_path(shipping_address), class: "btn btn-sm btn-success" %>
             </td>
             <td class="text-center">
               <%= link_to '削除する', shipping_address_path(shipping_address), method: :delete, data: { confirm: '本当に消しますか？' }, class: "btn btn-sm btn-danger"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,7 @@ Rails.application.routes.draw do
     get 'homes/top'
   end
   scope module: :public do
-    get 'shipping_addresses' => 'shipping_addresses#index'
-    get 'shipping_addresses/id/edit' => 'shipping_addresses#edit', as: 'shipping_addresses_edit'
+    resources :shipping_addresses, only:  [:index, :create, :edit, :update, :destroy]
   end
   scope module: :public do
     get 'orders' => 'orders#index'


### PR DESCRIPTION
## 商品一覧・商品詳細のレイアウト編集
- ジャンル検索のテンプレート化
- 商品一覧のテンプレート化（商品一覧とHOME TOP）
- 商品詳細のレイアウト編集（画像サイズは適当です）
- 商品一覧に商品新規追加ボタンを追加
- 会員一覧のレイアウト編集（忘れていました）